### PR TITLE
make sure the tooltip stays in window-space when loading positions

### DIFF
--- a/frame.html
+++ b/frame.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <script src="skinnytip.js"></script>
+</head>
+<body style="background-color:lightgray; padding:0;margin:0;width:100%;height:100%;">
+
+
+
+<div style="width: 100%;margin-top:150px;">
+    <div style="float:right;" class="skinnytip" data-text="This is the contaökl shfaöls dkfhasölfjaölsfj ölksajf </br>ents of the tooltip">Too much right    </div>
+</div>
+<br>
+
+<div style="width: 100%;margin-top:100px;">
+    <div style="float:left;" class="skinnytip" data-text="This is the contaökl shfaöls dkfhasölfjaölsfj ölksajf </br>ents of the tooltip">Too much bottom</div>
+</div>
+
+
+<script>SkinnyTip.init();</script>
+</body>
+</html>

--- a/skinnytip.js
+++ b/skinnytip.js
@@ -211,12 +211,33 @@ SkinnyTip.position = function() {
 
 //get horizontal box placement
 SkinnyTip.getXPlacement = function() {
-	return this.mouseX + parseInt(this.xOffset);
+
+	var posX=this.mouseX + parseInt(this.xOffset);
+	var widthInt=parseInt(this.width);
+	var borderWidthInt=parseInt(this.border)+3;
+
+	//make sure tooltip fits in window.width
+	if(posX+widthInt+borderWidthInt>window.innerWidth){
+		posX=posX-(posX+widthInt+borderWidthInt-window.innerWidth);
+	}
+
+	return posX;
 };
 
 //get vertical box placement
 SkinnyTip.getYPlacement = function() {
-	return this.mouseY + parseInt(this.yOffset);
+
+	var posY=this.mouseY + parseInt(this.yOffset);
+
+	var heightInt=parseInt(document.getElementById(this.divId).scrollHeight);
+	var borderWidthInt=parseInt(this.border)+3;
+
+	//make sure tooltip fits in window.height
+	if(posY+heightInt+borderWidthInt>window.innerHeight){
+		posY=posY-(posY+heightInt+borderWidthInt-window.innerHeight);
+	}
+
+	return posY;
 };
 
 //Creates the popup

--- a/test.html
+++ b/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+
+    <iframe src="frame.html" style="border-style:solid;width: 550px;height:300px;" scrolling="no"></iframe>
+
+</body>
+</html>


### PR DESCRIPTION
When skinnytip is used in an iframe, it often happens that the tooltip floats out of the iframe-window.
This fix checks the current window-width and repositions the tooltip if nessesary